### PR TITLE
Publish docker images to platforms: linux/amd64 and linux/arm64

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -40,5 +40,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This is useful for user trying out a local run of this docker image on a Mac. Today. this would return a Docker error on M1 Mac.
```
~ docker run --rm -it docker.io/cloudflare/hello-world:1.0

Unable to find image 'cloudflare/hello-world:1.0' locally
1.0: Pulling from cloudflare/hello-world
docker: no matching manifest for linux/arm64/v8 in the manifest list entries.
See 'docker run --help'.
```