### PR TITLE
Use docker buildx action to support multiple platforms

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -33,6 +33,9 @@ jobs:
         with:
           images: cloudflare/hello-world
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -33,6 +33,9 @@ jobs:
         with:
           images: cloudflare/hello-world
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
From https://docs.docker.com/build/ci/github-actions/multi-platform/, platform support needs docker buildx. 